### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - curl -L https://goss.rocks/install | sudo sh
+
+script:
+  - cd tests && ./test.sh

--- a/tests/7.0/goss.yaml
+++ b/tests/7.0/goss.yaml
@@ -1,0 +1,42 @@
+command:
+  php -m:
+    exit-status: 0
+    stdout:
+    - '[PHP Modules]'
+    - Core
+    - ctype
+    - curl
+    - date
+    - dom
+    - fileinfo
+    - filter
+    - ftp
+    - hash
+    - iconv
+    - json
+    - libxml
+    - mbstring
+    - mysqlnd
+    - openssl
+    - pcre
+    - PDO
+    - pdo_sqlite
+    - Phar
+    - posix
+    - readline
+    - Reflection
+    - session
+    - SimpleXML
+    - SPL
+    - sqlite3
+    - standard
+    - tokenizer
+    - xdebug
+    - xml
+    - xmlreader
+    - xmlwriter
+    - zlib
+    - '[Zend Modules]'
+    - Xdebug
+    stderr: []
+    timeout: 10000

--- a/tests/7.1/goss.yaml
+++ b/tests/7.1/goss.yaml
@@ -1,0 +1,42 @@
+command:
+  php -m:
+    exit-status: 0
+    stdout:
+    - '[PHP Modules]'
+    - Core
+    - ctype
+    - curl
+    - date
+    - dom
+    - fileinfo
+    - filter
+    - ftp
+    - hash
+    - iconv
+    - json
+    - libxml
+    - mbstring
+    - mysqlnd
+    - openssl
+    - pcre
+    - PDO
+    - pdo_sqlite
+    - Phar
+    - posix
+    - readline
+    - Reflection
+    - session
+    - SimpleXML
+    - SPL
+    - sqlite3
+    - standard
+    - tokenizer
+    - xdebug
+    - xml
+    - xmlreader
+    - xmlwriter
+    - zlib
+    - '[Zend Modules]'
+    - Xdebug
+    stderr: []
+    timeout: 10000

--- a/tests/7.2/goss.yaml
+++ b/tests/7.2/goss.yaml
@@ -1,0 +1,42 @@
+command:
+  php -m:
+    exit-status: 0
+    stdout:
+    - '[PHP Modules]'
+    - Core
+    - ctype
+    - curl
+    - date
+    - dom
+    - fileinfo
+    - filter
+    - ftp
+    - hash
+    - iconv
+    - json
+    - libxml
+    - mbstring
+    - mysqlnd
+    - openssl
+    - pcre
+    - PDO
+    - pdo_sqlite
+    - Phar
+    - posix
+    - readline
+    - Reflection
+    - session
+    - SimpleXML
+    - SPL
+    - sqlite3
+    - standard
+    - tokenizer
+    - xdebug
+    - xml
+    - xmlreader
+    - xmlwriter
+    - zlib
+    - '[Zend Modules]'
+    - Xdebug
+    stderr: []
+    timeout: 10000

--- a/tests/7.3/goss.yaml
+++ b/tests/7.3/goss.yaml
@@ -1,0 +1,42 @@
+command:
+  php -m:
+    exit-status: 0
+    stdout:
+    - '[PHP Modules]'
+    - Core
+    - ctype
+    - curl
+    - date
+    - dom
+    - fileinfo
+    - filter
+    - ftp
+    - hash
+    - iconv
+    - json
+    - libxml
+    - mbstring
+    - mysqlnd
+    - openssl
+    - pcre
+    - PDO
+    - pdo_sqlite
+    - Phar
+    - posix
+    - readline
+    - Reflection
+    - session
+    - SimpleXML
+    - SPL
+    - sqlite3
+    - standard
+    - tokenizer
+    - xdebug
+    - xml
+    - xmlreader
+    - xmlwriter
+    - zlib
+    - '[Zend Modules]'
+    - Xdebug
+    stderr: []
+    timeout: 10000

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+dir_list=$(ls -d */ | sed 's/\/*$//g')
+
+for dir in $dir_list
+do
+(
+    docker build -t phpcli/php-$dir -f ../$dir/Dockerfile ../$dir
+    cd $dir
+    dgoss run -it phpcli/php-$dir
+)
+done


### PR DESCRIPTION
# Changed log
- Add Travis CI build
- Using the `dgoss` tool to expect PHP extensions has been loaded correctly.

The Travis build log is [here](https://travis-ci.org/peter279k/phpcli/builds/535844398).